### PR TITLE
[FEAT] Replace git submodule by Artifact

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/translation/matlab"]
-	path = test/translation/matlab
-	url = https://github.com/EPFL-ENAC/URBES-utc-test-data

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,0 +1,7 @@
+[utcdata]
+git-tree-sha1 = "487b43548c5faa083dce9d10a222c2b5f67b293a"
+lazy = true
+
+    [[utcdata.download]]
+    url = "https://github.com/EPFL-ENAC/URBES-utc-test-data/raw/refs/heads/feat-add-tar/utcdata.tar.gz"
+    sha256 = "dbeb604faed0cc6bfc6990996d0ca3e69ad3ce8cb315d8329940a60e2589c19f"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -20,6 +20,46 @@ using UrbanTethysChloris.ModelComponents.Parameters:
     VegetatedSoilParameters,
     WallSoilParameters,
     WindowParameters
+using MAT
+using Artifacts
+
+# using Pkg
+# using Artifacts
+
+# toml = Artifacts.find_artifacts_toml(@__DIR__)
+# const datadir = Pkg.Artifacts.ensure_artifact_installed("utcdata", toml)
+
+"""
+    load_matlab_data(path::String)
+
+Load MATLAB data from MAT files containing input and output variables.
+
+This function reads paired input/output MAT files that were generated from MATLAB data.
+It converts the file paths to point to corresponding MAT files and reads both input
+and output data, converting special values as needed.
+
+# Arguments
+- `path::String`: Base path to the MAT files. If path ends in ".jl", it will be converted to ".json"
+
+# Returns
+- `Tuple{Any,Any}`: A tuple containing:
+  - `inputVars`: Processed input variables from the input MAT file
+  - `outputVars`: Processed output variables from the output MAT file
+
+# Notes
+- Files are expected to be in "utcdata" artifact
+- Numbers are parsed as Float64
+
+"""
+function load_matlab_data(func_name::String)
+    FT = Float64
+
+    dir = artifact"utcdata"
+    inputVars = matread(joinpath(dir, "data", "inputs", func_name))
+    outputVars = matread(joinpath(dir, "data", "outputs", func_name))
+
+    return inputVars, outputVars
+end
 
 """
     load_test_netcdf(path::String = joinpath(@__DIR__, "data", "input_data.nc"))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -21,6 +21,7 @@ using UrbanTethysChloris.ModelComponents.Parameters:
     WallSoilParameters,
     WindowParameters
 using MAT
+using LazyArtifacts
 using Artifacts
 
 # using Pkg

--- a/test/translation/julia/building_energy_model/ac_heating_module.jl
+++ b/test/translation/julia/building_energy_model/ac_heating_module.jl
@@ -1,13 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: ac_heating_module
-using ....TestUtils: create_hvac_parameters
+using ....TestUtils: create_hvac_parameters, load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.AC_HeatingModule.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.AC_HeatingModule.mat")
 
 ParHVAC = create_hvac_parameters(FT; MasterOn=Bool(input_vars["ParHVAC"]["MasterOn"]))
 

--- a/test/translation/julia/building_energy_model/ac_heating_turn_on_off.jl
+++ b/test/translation/julia/building_energy_model/ac_heating_turn_on_off.jl
@@ -1,13 +1,11 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: ac_heating_turn_on_off
-using ....TestUtils: create_urban_geometry_parameters, create_hvac_parameters
+using ....TestUtils:
+    create_urban_geometry_parameters, create_hvac_parameters, load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.AC_HeatingTurnOnOff.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.AC_HeatingTurnOnOff.mat")
 
 # Create input NamedTuples from MATLAB data
 ParHVAC = create_hvac_parameters(

--- a/test/translation/julia/building_energy_model/conductive_heat_flux_building_floor.jl
+++ b/test/translation/julia/building_energy_model/conductive_heat_flux_building_floor.jl
@@ -1,13 +1,12 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: conductive_heat_flux_building_floor
-using ....TestUtils: create_thermal_building
+using ....TestUtils: create_thermal_building, load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.ConductiveHeatFluxFR_BuildingFloor.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "BuildingEnergyModel.ConductiveHeatFluxFR_BuildingFloor.mat"
+)
 
 ParCalculation = (dts=Int(input_vars["ParCalculation"]["dts"]),)
 ParThermalBuildFloor = create_thermal_building(

--- a/test/translation/julia/building_energy_model/eb_solver_building.jl
+++ b/test/translation/julia/building_energy_model/eb_solver_building.jl
@@ -6,13 +6,11 @@ using ....TestUtils:
     create_hvac_parameters,
     create_indoor_optical_properties,
     create_thermal_building,
-    create_window_parameters
+    create_window_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.EBSolver_Building.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.EBSolver_Building.mat")
 
 # Create parameter structs from input data
 Geometry_m = create_urban_geometry_parameters(

--- a/test/translation/julia/building_energy_model/eb_solver_building_output.jl
+++ b/test/translation/julia/building_energy_model/eb_solver_building_output.jl
@@ -6,13 +6,13 @@ using ....TestUtils:
     create_hvac_parameters,
     create_indoor_optical_properties,
     create_thermal_building,
-    create_window_parameters
+    create_window_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.EBSolver_BuildingOUTPUT.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "BuildingEnergyModel.EBSolver_BuildingOUTPUT.mat"
+)
 
 # Create parameter structs from input data
 Geometry_m = create_urban_geometry_parameters(

--- a/test/translation/julia/building_energy_model/heat_storage_change_internal_mass.jl
+++ b/test/translation/julia/building_energy_model/heat_storage_change_internal_mass.jl
@@ -1,13 +1,13 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: heat_storage_change_internal_mass
-using ....TestUtils: create_urban_geometry_parameters, create_thermal_building
+using ....TestUtils:
+    create_urban_geometry_parameters, create_thermal_building, load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.HeatStorageChangeInternalMass.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "BuildingEnergyModel.HeatStorageChangeInternalMass.mat"
+)
 
 ParThermalBuildFloor = create_thermal_building(
     FT;

--- a/test/translation/julia/building_energy_model/lwr_abs_building_half.jl
+++ b/test/translation/julia/building_energy_model/lwr_abs_building_half.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: lwr_abs_building_half
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.LWRabsBuildingHalf.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.LWRabsBuildingHalf.mat")
 
 @testset "MATLAB" begin
     LWRinB, LWRoutB, LWRabsB = lwr_abs_building_half(

--- a/test/translation/julia/building_energy_model/lwr_abs_indoors.jl
+++ b/test/translation/julia/building_energy_model/lwr_abs_indoors.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: lwr_abs_indoors
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "building_energy_model.LWRabsIndoors.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.LWRabsIndoors.mat")
 
 @testset "MATLAB" begin
     LWRinB, LWRoutB, LWRabsB = lwr_abs_indoors(

--- a/test/translation/julia/building_energy_model/lwr_abs_indoors_no_int_mass.jl
+++ b/test/translation/julia/building_energy_model/lwr_abs_indoors_no_int_mass.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: lwr_abs_indoors_no_int_mass
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.LWRabsIndoorsNoIntMass.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.LWRabsIndoorsNoIntMass.mat")
 
 @testset "MATLAB" begin
     LWRinB, LWRoutB, LWRabsB, LWREBB = lwr_abs_indoors_no_int_mass(

--- a/test/translation/julia/building_energy_model/sensible_heat_flux_building_interior.jl
+++ b/test/translation/julia/building_energy_model/sensible_heat_flux_building_interior.jl
@@ -1,12 +1,12 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: sensible_heat_flux_building_interior
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.SensibleHeatFluxBuildingInterior.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "BuildingEnergyModel.SensibleHeatFluxBuildingInterior.mat"
+)
 
 @testset "MATLAB" begin
     HbinWallSun, HbinWallshd, HBinRoof, HBinGround, HbinIntMass, HbinWindow = sensible_heat_flux_building_interior(

--- a/test/translation/julia/building_energy_model/swr_abs_building_half.jl
+++ b/test/translation/julia/building_energy_model/swr_abs_building_half.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: swr_abs_building_half
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "building_energy_model.SWRabsBuildingHalf.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.SWRabsBuildingHalf.mat")
 
 @testset "MATLAB" begin
     SWRinB, SWRoutB, SWRabsB = swr_abs_building_half(

--- a/test/translation/julia/building_energy_model/swr_abs_indoors.jl
+++ b/test/translation/julia/building_energy_model/swr_abs_indoors.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: swr_abs_indoors
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "building_energy_model.SWRabsIndoors.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.SWRabsIndoors.mat")
 
 @testset "MATLAB" begin
     SWRinB, SWRoutB, SWRabsB = swr_abs_indoors(

--- a/test/translation/julia/building_energy_model/swr_abs_indoors_no_int_mass.jl
+++ b/test/translation/julia/building_energy_model/swr_abs_indoors_no_int_mass.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.BuildingEnergyModel: swr_abs_indoors_no_int_mass
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.SWRabsIndoorsNoIntMass.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.SWRabsIndoorsNoIntMass.mat")
 
 @testset "MATLAB" begin
     SWRinB, SWRoutB, SWRabsB, SWREBB = swr_abs_indoors_no_int_mass(

--- a/test/translation/julia/conductive_heat/conductive_heat_flux_green_roof.jl
+++ b/test/translation/julia/conductive_heat/conductive_heat_flux_green_roof.jl
@@ -4,13 +4,13 @@ using UrbanTethysChloris.ConductiveHeat: conductive_heat_flux_green_roof
 using ....TestUtils:
     create_height_dependent_vegetation_parameters,
     create_vegetated_soil_parameters,
-    create_location_specific_thermal_properties
+    create_location_specific_thermal_properties,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "conductive_heat_functions.ConductiveHeatFlux_GreenRoof.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "conductive_heat_functions.ConductiveHeatFlux_GreenRoof.mat"
+)
 
 # Create parameter structs from input data
 ParVegRoof = create_height_dependent_vegetation_parameters(

--- a/test/translation/julia/conductive_heat/conductive_heat_flux_ground_fr.jl
+++ b/test/translation/julia/conductive_heat/conductive_heat_flux_ground_fr.jl
@@ -5,13 +5,13 @@ using ....TestUtils:
     create_location_specific_thermal_properties,
     create_location_specific_surface_fractions,
     create_vegetated_soil_parameters,
-    create_height_dependent_vegetation_parameters
+    create_height_dependent_vegetation_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "conductive_heat_functions.ConductiveHeatFluxFR_GroundImp.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "conductive_heat_functions.ConductiveHeatFluxFR_GroundImp.mat"
+)
 
 # Create parameter structs from input data
 ParThermalGround = create_location_specific_thermal_properties(

--- a/test/translation/julia/conductive_heat/conductive_heat_flux_ground_vb.jl
+++ b/test/translation/julia/conductive_heat/conductive_heat_flux_ground_vb.jl
@@ -5,13 +5,13 @@ using ....TestUtils:
     create_location_specific_thermal_properties,
     create_location_specific_surface_fractions,
     create_vegetated_soil_parameters,
-    create_height_dependent_vegetation_parameters
+    create_height_dependent_vegetation_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "conductive_heat_functions.ConductiveHeatFluxFR_GroundVegBare.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "conductive_heat_functions.ConductiveHeatFluxFR_GroundVegBare.mat"
+)
 
 # Create parameter structs from input data
 FractionsGround = create_location_specific_surface_fractions(

--- a/test/translation/julia/conductive_heat/conductive_heat_flux_roof_imp.jl
+++ b/test/translation/julia/conductive_heat/conductive_heat_flux_roof_imp.jl
@@ -2,13 +2,14 @@ using Test
 using MAT
 using UrbanTethysChloris.ConductiveHeat: conductive_heat_flux_roof_imp
 using ....TestUtils:
-    create_vegetated_soil_parameters, create_location_specific_thermal_properties
+    create_vegetated_soil_parameters,
+    create_location_specific_thermal_properties,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "conductive_heat_functions.ConductiveHeatFlux_RoofImp.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "conductive_heat_functions.ConductiveHeatFlux_RoofImp.mat"
+)
 
 # Create parameter structs from input data
 ParThermalRoof = create_location_specific_thermal_properties(

--- a/test/translation/julia/conductive_heat/conductive_heat_flux_walls.jl
+++ b/test/translation/julia/conductive_heat/conductive_heat_flux_walls.jl
@@ -1,13 +1,13 @@
 using Test
 using MAT
 using UrbanTethysChloris.ConductiveHeat: conductive_heat_flux_walls
-using ....TestUtils: create_location_specific_thermal_properties, create_window_parameters
+using ....TestUtils:
+    create_location_specific_thermal_properties, create_window_parameters, load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "conductive_heat_functions.ConductiveHeatFlux_Walls.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "conductive_heat_functions.ConductiveHeatFlux_Walls.mat"
+)
 
 # Create parameter structs from input data
 ParThermalWall = create_location_specific_thermal_properties(

--- a/test/translation/julia/conductive_heat/soil_heat.jl
+++ b/test/translation/julia/conductive_heat/soil_heat.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.ConductiveHeat: soil_heat
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "conductive_heat_functions.Soil_Heat.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("conductive_heat_functions.Soil_Heat.mat")
 
 @testset "MATLAB" begin
     G, Tdp = soil_heat(

--- a/test/translation/julia/mean_radiant_temperature/mean_radiant_temperature.jl
+++ b/test/translation/julia/mean_radiant_temperature/mean_radiant_temperature.jl
@@ -1,15 +1,14 @@
 using Test
 using MAT
 using UrbanTethysChloris.MeanRadiantTemperature: mean_radiant_temperature
-using ....TestUtils:
-    create_urban_geometry_parameters, create_height_dependent_vegetation_parameters
 using UrbanTethysChloris.RayTracing: ViewFactorPoint
+using ....TestUtils:
+    create_urban_geometry_parameters,
+    create_height_dependent_vegetation_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "MRT.MeanRadiantTemperature.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("MRT.MeanRadiantTemperature.mat")
 
 # Create parameter structs
 ParVegTree = create_height_dependent_vegetation_parameters(

--- a/test/translation/julia/mean_radiant_temperature/person_in_shade.jl
+++ b/test/translation/julia/mean_radiant_temperature/person_in_shade.jl
@@ -1,13 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.MeanRadiantTemperature: person_in_shade
-using ....TestUtils: create_height_dependent_vegetation_parameters
+using ....TestUtils: create_height_dependent_vegetation_parameters, load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "MRT.PersonInShadeYesOrNo.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("MRT.PersonInShadeYesOrNo.mat")
 
 # Create parameters
 ParVegTree = create_height_dependent_vegetation_parameters(

--- a/test/translation/julia/mean_radiant_temperature/swr_diff_person.jl
+++ b/test/translation/julia/mean_radiant_temperature/swr_diff_person.jl
@@ -2,12 +2,10 @@ using Test
 using MAT
 using UrbanTethysChloris.MeanRadiantTemperature: swr_diff_person
 using UrbanTethysChloris.RayTracing: ViewFactorPoint
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "MRT.SWRDiffPerson.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("MRT.SWRDiffPerson.mat")
 
 SWRout_t = (;
     SWRoutTotalGround=input_vars["SWRout_t"]["SWRoutTotalGround"],

--- a/test/translation/julia/mean_radiant_temperature/swr_dir_person.jl
+++ b/test/translation/julia/mean_radiant_temperature/swr_dir_person.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.MeanRadiantTemperature: swr_dir_person
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "MRT.SWRDirPerson.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("MRT.SWRDirPerson.mat")
 
 @testset "MATLAB" begin
     SWRdir_Person, SWRdir_in_top, SWRdir_in_bottom, SWRdir_in_east, SWRdir_in_south, SWRdir_in_west, SWRdir_in_north = swr_dir_person(

--- a/test/translation/julia/outdoor_thermal_comfort/utci_approx.jl
+++ b/test/translation/julia/outdoor_thermal_comfort/utci_approx.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.OutdoorThermalComfort: utci_approx
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "OTC.UTCI_approx.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("OTC.UTCI_approx.mat")
 
 @testset "MATLAB" begin
     UTCI = utci_approx(

--- a/test/translation/julia/ray_tracing/view_factor_internal.jl
+++ b/test/translation/julia/ray_tracing/view_factor_internal.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.RayTracing: view_factor_internal
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "BuildingEnergyModel.ViewFactorInternal.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("BuildingEnergyModel.ViewFactorInternal.mat")
 
 @testset "MATLAB" begin
     F_gc, F_gw, F_ww, F_wg, F_wc, F_cg, F_cw, ViewFactor = view_factor_internal(

--- a/test/translation/julia/resistance/precalculate_for_faster_numerical_solution.jl
+++ b/test/translation/julia/resistance/precalculate_for_faster_numerical_solution.jl
@@ -17,13 +17,13 @@ using ....TestUtils:
     create_vegetated_optical_properties,
     create_simple_optical_properties,
     create_height_dependent_vegetation_parameters,
-    create_window_parameters
+    create_window_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "resistance_functions.PrecalculateForFasterNumericalSolution.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "resistance_functions.PrecalculateForFasterNumericalSolution.mat"
+)
 
 # Convert Dict{String, Any} to named tuples
 TempVec_ittm = (;

--- a/test/translation/julia/resistance/precalculate_stomatal_resistance_ground_tree.jl
+++ b/test/translation/julia/resistance/precalculate_stomatal_resistance_ground_tree.jl
@@ -17,13 +17,13 @@ using ....TestUtils:
     create_vegetated_optical_properties,
     create_simple_optical_properties,
     create_height_dependent_vegetation_parameters,
-    create_window_parameters
+    create_window_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "resistance_functions.PrecalculateStomatalResistanceGroundTree.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "resistance_functions.PrecalculateStomatalResistanceGroundTree.mat"
+)
 
 # Convert Dict{String, Any} to named tuples
 TempVec_ittm = (;

--- a/test/translation/julia/resistance/precalculate_stomatal_resistance_roof.jl
+++ b/test/translation/julia/resistance/precalculate_stomatal_resistance_roof.jl
@@ -2,13 +2,14 @@ using Test
 using MAT
 using UrbanTethysChloris.Resistance: precalculate_stomatal_resistance_roof
 using ....TestUtils:
-    create_vegetated_optical_properties, create_height_dependent_vegetation_parameters
+    create_vegetated_optical_properties,
+    create_height_dependent_vegetation_parameters,
+    load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "resistance_functions.PrecalculateStomatalResistanceRoof.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data(
+    "resistance_functions.PrecalculateStomatalResistanceRoof.mat"
+)
 
 # convert Dict{String, Any} to a named tuple
 TempVec_ittm = (; TRoofVeg=input_vars["TempVec_ittm"]["TRoofVeg"])

--- a/test/translation/julia/soil/soil_parameters.jl
+++ b/test/translation/julia/soil/soil_parameters.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.Soil: soil_parameters
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "soil_functions.Soil_parameters.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("soil_functions.Soil_parameters.mat")
 
 @testset "MATLAB" begin
     Osat, L, Pe, Ks, O33, rsd, lan_dry, lan_s, cv_s, K_usle = soil_parameters(

--- a/test/translation/julia/soil/soil_parameters_total.jl
+++ b/test/translation/julia/soil/soil_parameters_total.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.Soil: soil_parameters_total
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "soil_functions.SoilParametersTotal.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("soil_functions.SoilParametersTotal.mat")
 
 @testset "MATLAB" begin
     Zs, dz, ms, Osat, Ohy, nVG, alpVG, Ks_Zs, L, Pe, O33, SPAR, EvL_Zs, Inf_Zs, RfH_Zs, RfL_Zs, Zinf, Kbot, Slo_pot, Dz, aR, aTop, rsd, lan_dry, lan_s, cv_s = soil_parameters_total(

--- a/test/translation/julia/turbulent_heat/air_humidity_2m.jl
+++ b/test/translation/julia/turbulent_heat/air_humidity_2m.jl
@@ -4,7 +4,11 @@ using UrbanTethysChloris.TurbulentHeat: air_humidity_2m
 using ....TestUtils:
     create_location_specific_surface_fractions,
     create_height_dependent_vegetation_parameters,
-    create_urban_geometry_parameters
+    create_urban_geometry_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data("turbulent_heat_function.AirHumidity2m.mat")
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/air_humidity_2m.jl
+++ b/test/translation/julia/turbulent_heat/air_humidity_2m.jl
@@ -10,12 +10,6 @@ using ....TestUtils:
 FT = Float64
 input_vars, output_vars = load_matlab_data("turbulent_heat_function.AirHumidity2m.mat")
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.AirHumidity2m.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 FractionsGround = create_location_specific_surface_fractions(
     FT;
     fveg=input_vars["FractionsGround"]["fveg"],

--- a/test/translation/julia/turbulent_heat/air_humidity_2m_output.jl
+++ b/test/translation/julia/turbulent_heat/air_humidity_2m_output.jl
@@ -12,12 +12,6 @@ input_vars, output_vars = load_matlab_data(
     "turbulent_heat_function.AirHumidity2mOutput.mat"
 )
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.AirHumidity2mOutput.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 FractionsGround = create_location_specific_surface_fractions(
     FT;
     fveg=input_vars["FractionsGround"]["fveg"],

--- a/test/translation/julia/turbulent_heat/air_humidity_2m_output.jl
+++ b/test/translation/julia/turbulent_heat/air_humidity_2m_output.jl
@@ -4,7 +4,13 @@ using UrbanTethysChloris.TurbulentHeat: air_humidity_2m_output
 using ....TestUtils:
     create_location_specific_surface_fractions,
     create_height_dependent_vegetation_parameters,
-    create_urban_geometry_parameters
+    create_urban_geometry_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data(
+    "turbulent_heat_function.AirHumidity2mOutput.mat"
+)
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/calculate_t2m.jl
+++ b/test/translation/julia/turbulent_heat/calculate_t2m.jl
@@ -10,12 +10,6 @@ using ....TestUtils:
 FT = Float64
 input_vars, output_vars = load_matlab_data("turbulent_heat_function.CalculateT2m.mat")
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.CalculateT2m.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 FractionsGround = create_location_specific_surface_fractions(
     FT;
     fveg=input_vars["FractionsGround"]["fveg"],

--- a/test/translation/julia/turbulent_heat/calculate_t2m.jl
+++ b/test/translation/julia/turbulent_heat/calculate_t2m.jl
@@ -4,7 +4,11 @@ using UrbanTethysChloris.TurbulentHeat: calculate_t2m
 using ....TestUtils:
     create_location_specific_surface_fractions,
     create_height_dependent_vegetation_parameters,
-    create_urban_geometry_parameters
+    create_urban_geometry_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data("turbulent_heat_function.CalculateT2m.mat")
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/heat_flux_canyon.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_canyon.jl
@@ -9,12 +9,6 @@ using ....TestUtils:
 FT = Float64
 input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_canyon.mat")
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.HeatFlux_canyon.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 Gemeotry_m = create_urban_geometry_parameters(
     FT;
     Height_canyon=input_vars["Gemeotry_m"]["Height_canyon"],

--- a/test/translation/julia/turbulent_heat/heat_flux_canyon.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_canyon.jl
@@ -2,7 +2,12 @@ using Test
 using MAT
 using UrbanTethysChloris.TurbulentHeat: heat_flux_canyon
 using ....TestUtils:
-    create_height_dependent_vegetation_parameters, create_urban_geometry_parameters
+    create_height_dependent_vegetation_parameters,
+    create_urban_geometry_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_canyon.mat")
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/heat_flux_ground.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_ground.jl
@@ -11,12 +11,6 @@ using ....TestUtils:
 FT = Float64
 input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_ground.mat")
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.HeatFlux_ground.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 # Create structured inputs with correct types
 FractionsGround = create_location_specific_surface_fractions(
     FT;

--- a/test/translation/julia/turbulent_heat/heat_flux_ground.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_ground.jl
@@ -5,7 +5,11 @@ using ....TestUtils:
     create_height_dependent_vegetation_parameters,
     create_location_specific_surface_fractions,
     create_urban_geometry_parameters,
-    create_vegetated_soil_parameters
+    create_vegetated_soil_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_ground.mat")
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/heat_flux_roof.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_roof.jl
@@ -5,7 +5,11 @@ using ....TestUtils:
     create_height_dependent_vegetation_parameters,
     create_location_specific_surface_fractions,
     create_urban_geometry_parameters,
-    create_vegetated_soil_parameters
+    create_vegetated_soil_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_roof.mat")
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/heat_flux_roof.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_roof.jl
@@ -11,12 +11,6 @@ using ....TestUtils:
 FT = Float64
 input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_roof.mat")
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.HeatFlux_roof.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 # Create structured inputs with correct types
 FractionsRoof = create_location_specific_surface_fractions(
     FT; fveg=input_vars["FractionsRoof"]["fveg"], fimp=input_vars["FractionsRoof"]["fimp"]

--- a/test/translation/julia/turbulent_heat/heat_flux_wall.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_wall.jl
@@ -4,7 +4,11 @@ using UrbanTethysChloris.TurbulentHeat: heat_flux_wall
 using ....TestUtils:
     create_height_dependent_vegetation_parameters,
     create_location_specific_surface_fractions,
-    create_urban_geometry_parameters
+    create_urban_geometry_parameters,
+    load_matlab_data
+
+FT = Float64
+input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_wall.mat")
 
 FT = Float64
 dir = joinpath(@__DIR__, "..", "..", "matlab", "data")

--- a/test/translation/julia/turbulent_heat/heat_flux_wall.jl
+++ b/test/translation/julia/turbulent_heat/heat_flux_wall.jl
@@ -10,12 +10,6 @@ using ....TestUtils:
 FT = Float64
 input_vars, output_vars = load_matlab_data("turbulent_heat_function.HeatFlux_wall.mat")
 
-FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "turbulent_heat_function.HeatFlux_wall.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
-
 Gemeotry_m = create_urban_geometry_parameters(
     FT;
     Height_canyon=input_vars["Gemeotry_m"]["Height_canyon"],

--- a/test/translation/julia/water/water_vegetation.jl
+++ b/test/translation/julia/water/water_vegetation.jl
@@ -1,12 +1,10 @@
 using Test
 using MAT
 using UrbanTethysChloris.Water: water_vegetation
+using ....TestUtils: load_matlab_data
 
 FT = Float64
-dir = joinpath(@__DIR__, "..", "..", "matlab", "data")
-filename = "water_functions.Water_Vegetation.mat"
-input_vars = matread(joinpath(dir, "inputs", filename))
-output_vars = matread(joinpath(dir, "outputs", filename))
+input_vars, output_vars = load_matlab_data("water_functions.Water_Vegetation.mat")
 
 @testset "Zurich" begin
     q_runon_veg, In_veg, dIn_veg_dt, WBalance_In_veg = water_vegetation(


### PR DESCRIPTION
git submodules cannot be used by Julia packages if said packages are expected to be installed via Pkg. This PR replaces the (nested) git submodules responsible for creating the data used to test the translation's accuracy by a lazy Artifact downloaded iff the tests are run.

## Related issues
Closes #90 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/EPFL-ENAC/UrbanTethysChloris.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
