### PR TITLE
[BUILD] Replace TethysChlorisCore GitHub url with direct call to Pkg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TethysChlorisCore = "c22758e7-e854-5bdb-8df2-7602c47a9d98"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
-[sources]
-TethysChlorisCore = {rev = "v0.1.2", url = "https://github.com/EPFL-ENAC/TethysChlorisCore.jl"}
-
 [compat]
 ADTypes = "1.14.0"
 ConstructionBase = "1.6.0"
@@ -35,6 +32,6 @@ OrdinaryDiffEqRosenbrock = "1.10.0"
 Roots = "2.2.7"
 StaticArrays = "1.9.13"
 Statistics = "1.11.1"
-TethysChlorisCore = "0.1.2"
+TethysChlorisCore = "0.1.3"
 YAML = "0.4"
 julia = "1.11"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -13,9 +13,5 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TethysChlorisCore = "c22758e7-e854-5bdb-8df2-7602c47a9d98"
 UrbanTethysChloris = "8ae36e77-b357-5cab-a873-ceeadc1a5254"
 
-[sources]
-TethysChlorisCore = {rev = "v0.1.2", url = "https://github.com/EPFL-ENAC/TethysChlorisCore.jl"}
-
 [compat]
 Documenter = "1"
-TethysChlorisCore = "0.1.2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,6 +11,3 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TethysChlorisCore = "c22758e7-e854-5bdb-8df2-7602c47a9d98"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-
-[sources]
-TethysChlorisCore = {url = "https://github.com/EPFL-ENAC/TethysChlorisCore.jl"}


### PR DESCRIPTION
This PR switches TethysChlorisCore from a GitHub add to a Julia general registry dependence

## Related issues

There is no related issue.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/EPFL-ENAC/UrbanTethysChloris.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
