### PR TITLE
fix: correct dubai and lagos crashes

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Julia cache
         uses: julia-actions/cache@v2
       - name: Install Julia packages
-        run: julia -e 'using Pkg; pkg"add JuliaFormatter"'
+        run: julia -e 'using Pkg; pkg"add JuliaFormatter@2.2.1"'
       - name: Hack for setup-python cache # https://github.com/actions/setup-python/issues/807
         run: touch requirements.txt
       - name: Setup Python

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run pre-commit
-        run: SKIP=no-commit-to-branch pre-commit run -a
+        run: SKIP=no-commit-to-branch pre-commit run -a --show-diff-on-failure
   link-checker:
     name: Link checker
     runs-on: ubuntu-latest

--- a/src/f_solver_tot.jl
+++ b/src/f_solver_tot.jl
@@ -384,7 +384,7 @@ function f_solver_tot(
             r[14] = -1e-4
             r[22] = -1e-4
         else
-            r = (-1 + 2 * rand(FT, 22)) .* 3
+            r = (-1 .+ 2 * rand(FT, 22)) .* 3
             r[14] = -1e-4
             r[22] = -1e-4
         end

--- a/src/run_simulation.jl
+++ b/src/run_simulation.jl
@@ -1,7 +1,8 @@
-function run_simulation(
+"""
+    run_simulation(
     model::Model{FT},
     forcing::UrbanTethysChloris.ModelComponents.ForcingInputSet{FT,1};
-    NN::Signed=nothing,
+    NN::Union{Int,Missing}=missing,
     mc_sample_size::Int=1000,
     n_rays::Int=200,
     RESPreCalc::Bool=true,
@@ -15,6 +16,47 @@ function run_simulation(
     O33::NamedTuple=(roof=FT(0.0), ground=FT(0.0)),
     output_level::UrbanTethysChloris.ModelComponents.AbstractOutputsToSave=plot_outputs,
 ) where {FT<:AbstractFloat}
+
+# Arguments
+- model: The UrbanTethysChloris model object containing the parameters and variables for the simulation.
+- forcing: The forcing input set containing meteorological data for the simulation.
+- NN: The number of time steps to simulate. If missing, it will be set to the length of the forcing data minus one.
+- mc_sample_size: The number of Monte Carlo samples to use for view factor calculations. Defaults to 1000.
+- n_rays: The number of rays to use for view factor calculations. Defaults to 200.
+- RESPreCalc: Whether to pre-calculate resistances for faster numerical solution. Defaults to true
+- fconvPreCalc: Whether to pre-calculate convective heat transfer coefficients for faster numerical solution. Defaults to true.
+- BEM_on: Whether to enable the building energy model. Defaults to true.
+- WallLayers: The wall layer thicknesses for the building energy model. Defaults to 0.1 m for both layers.
+- ParInterceptionTree: The parameters for tree interception. Defaults to 0.2 m for Sp_In.
+- ViewFactors: The view factors for the simulation. If nothing, they will be calculated using the model parameters. Defaults to nothing.
+- O33: The initial water fluxes for the roof and ground. Defaults to 0 for both.
+- output_level: The level of outputs to save. Defaults to plot_outputs.
+
+# Returns
+- results: A dictionary containing the simulation results.
+- ViewFactor: The view factor object used in the simulation.
+- ViewFactorPoint: The view factor point object used in the simulation.
+"""
+function run_simulation(
+    model::Model{FT},
+    forcing::UrbanTethysChloris.ModelComponents.ForcingInputSet{FT,1};
+    NN::Union{Int,Missing}=missing,
+    mc_sample_size::Int=1000,
+    n_rays::Int=200,
+    RESPreCalc::Bool=true,
+    fconvPreCalc::Bool=true,
+    BEM_on::Bool=true,
+    WallLayers::NamedTuple=(; dz1_wall=FT(0.1), dz2_wall=FT(0.1)),
+    ParInterceptionTree::NamedTuple=(; Sp_In=FT(0.2)),
+    ViewFactors::Union{
+        Tuple{RayTracing.ViewFactor{FT},RayTracing.ViewFactorPoint{FT}},Nothing
+    }=nothing,
+    O33::NamedTuple=(roof=FT(0.0), ground=FT(0.0)),
+    output_level::UrbanTethysChloris.ModelComponents.AbstractOutputsToSave=plot_outputs,
+) where {FT<:AbstractFloat}
+    if ismissing(NN)
+        NN = length(forcing.datetime) - 1
+    end
 
     # view factor
     if isnothing(ViewFactors)


### PR DESCRIPTION
This PR fixes the following issue described by @liantaiqi and tweaks the passing of timesteps to `run_simulation`.

> However, when I start to run Julia in Dubai with full length of data (8760, instead of 100 in the test case). I got error (see attachment). Then I skip Dubai to test Lagos, the same error happened. I guess it's because of some lower branch functions are used in Dubai and Lagos and cause this issue? The model crashed after ~10 minutes running.

```julia
> julia --project=examples examples\dubai\run_dubai_save_results.jl
Running dubai simulation for NN=8760 / 8760 timesteps.
ERROR: LoadError: MethodError: no method matching +(::Int64, ::Vector{Float64})
For element-wise addition, use broadcasting with dot syntax: scalar .+ array
The function `+` exists, but no method is defined for this combination of argument types.
Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:596
  +(::Int64, ::ManualMemory.PseudoPtr)
   @ ManualMemory C:\Users\tlian\.julia\packages\ManualMemory\iySrG\src\ManualMemory.jl:42
  +(::Real, ::Complex{Bool})
   @ Base complex.jl:322
  ...
Stacktrace:
 [1] f_solver_tot(TempVec_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempVec{Float64}, TempVecB_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempVecB{Float64}, Humidity_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Humidity{Float64}, MeteoData::UrbanTethysChloris.ModelComponents.ForcingInputs.MeteorologicalInputs{Float64, 0}, Int_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Interception{Float64}, ExWater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.ExWater{Float64, 4, 13}, Vwater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Vwater{Float64, 4, 13}, Owater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Owater{Float64, 4, 13}, SoilPotW_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.SoilPotW{Float64}, CiCO2Leaf_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.CiCO2Leaf{Float64}, TempDamp_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempDamp{Float64}, ViewFactor::UrbanTethysChloris.RayTracing.ViewFactor{Float64}, Gemeotry_m::UrbanTethysChloris.ModelComponents.Parameters.UrbanGeometryParameters{Float64}, FractionsGround::UrbanTethysChloris.ModelComponents.Parameters.LocationSpecificSurfaceFractions{Float64}, FractionsRoof::UrbanTethysChloris.ModelComponents.Parameters.LocationSpecificSurfaceFractions{Float64}, WallLayers::@NamedTuple{dz1_wall::Float64, dz2_wall::Float64}, ParSoilGround::UrbanTethysChloris.ModelComponents.Parameters.VegetatedSoilParameters{Float64}, ParInterceptionTree::@NamedTuple{Sp_In::Float64}, PropOpticalGround::UrbanTethysChloris.ModelComponents.Parameters.VegetatedOpticalProperties{Float64}, PropOpticalWall::UrbanTethysChloris.ModelComponents.Parameters.SimpleOpticalProperties{Float64}, PropOpticalTree::UrbanTethysChloris.ModelComponents.Parameters.SimpleOpticalProperties{Float64}, ParThermalGround::UrbanTethysChloris.ModelComponents.Parameters.LocationSpecificThermalProperties{Float64}, ParThermalWall::UrbanTethysChloris.ModelComponents.Parameters.LocationSpecificThermalProperties{Float64}, ParVegGround::UrbanTethysChloris.ModelComponents.Parameters.HeightDependentVegetationParameters{Float64}, ParVegTree::UrbanTethysChloris.ModelComponents.Parameters.HeightDependentVegetationParameters{Float64}, ParSoilRoof::UrbanTethysChloris.ModelComponents.Parameters.VegetatedSoilParameters{Float64}, PropOpticalRoof::UrbanTethysChloris.ModelComponents.Parameters.VegetatedOpticalProperties{Float64}, ParThermalRoof::UrbanTethysChloris.ModelComponents.Parameters.LocationSpecificThermalProperties{Float64}, ParVegRoof::UrbanTethysChloris.ModelComponents.Parameters.HeightDependentVegetationParameters{Float64}, SunPosition::UrbanTethysChloris.ModelComponents.ForcingInputs.SunPositionInputs{Float64, 0}, HumidityAtm::UrbanTethysChloris.ModelComponents.ForcingInputs.MeteorologicalInputs{Float64, 0}, Anthropogenic::UrbanTethysChloris.ModelComponents.ForcingInputs.AnthropogenicInputs{Float64, 0}, ParCalculation::@NamedTuple{dth::Float64, dts::Int64, row::Float64, cp_atm::Float64, rho_atm::Float64}, PropOpticalIndoors::UrbanTethysChloris.ModelComponents.Parameters.IndoorOpticalProperties{Float64}, ParHVAC::UrbanTethysChloris.ModelComponents.Parameters.HVACParameters{Float64}, ParThermalBuildingFloor::UrbanTethysChloris.ModelComponents.Parameters.ThermalBuilding{Float64}, ParWindows::UrbanTethysChloris.ModelComponents.Parameters.WindowParameters{Float64}, BEM_on::Bool, TempVec_ittm2Ext::UrbanTethysChloris.ExtrapolatedTempVec{Float64}, Humidity_ittm2Ext::UrbanTethysChloris.ExtrapolatedHumidity{Float64}, TempVecB_ittm2Ext::UrbanTethysChloris.ExtrapolatedTempVecB{Float64}, Meteo_ittm::UrbanTethysChloris.Meteotm1{Float64}, RESPreCalc::Bool, fconvPreCalc::Bool, fconv::Float64, rsRoofPreCalc::@NamedTuple{rs_sun::Float64, rs_shd::Float64, Ci_sun::Float64, Ci_shd::Float64}, rsGroundPreCalc::@NamedTuple{rs_sun_L::Float64, rs_shd_L::Float64, Ci_sun_L::Float64, Ci_shd_L::Float64}, rsTreePreCalc::@NamedTuple{rs_sun_H::Float64, rs_shd_H::Float64, Ci_sun_H::Float64, Ci_shd_H::Float64}, HVACSchedule::UrbanTethysChloris.ModelComponents.ForcingInputs.HVACSchedule{Float64, 0}; iterations::Int64, f_tol::Float64)
   @ UrbanTethysChloris F:\TRANSCODE_UTC\Julia\src\f_solver_tot.jl:387
 [2] f_solver_tot
   @ F:\TRANSCODE_UTC\Julia\src\f_solver_tot.jl:176 [inlined]
 [3] f_solver_tot!(model::UrbanTethysChloris.Model{Float64}, TempVec_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempVec{Float64}, TempVecB_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempVecB{Float64}, Humidity_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Humidity{Float64}, Int_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Interception{Float64}, ExWater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.ExWater{Float64, 4, 13}, Vwater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Vwater{Float64, 4, 13}, Owater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Owater{Float64, 4, 13}, SoilPotW_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.SoilPotW{Float64}, CiCO2Leaf_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.CiCO2Leaf{Float64}, TempDamp_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempDamp{Float64}, ViewFactor::UrbanTethysChloris.RayTracing.ViewFactor{Float64}, WallLayers::@NamedTuple{dz1_wall::Float64, dz2_wall::Float64}, ParInterceptionTree::@NamedTuple{Sp_In::Float64}, ParCalculation::@NamedTuple{dth::Float64, dts::Int64, row::Float64, cp_atm::Float64, rho_atm::Float64}, ParHVAC::UrbanTethysChloris.ModelComponents.Parameters.HVACParameters{Float64}, BEM_on::Bool, TempVec_ittm2Ext::UrbanTethysChloris.ExtrapolatedTempVec{Float64}, Humidity_ittm2Ext::UrbanTethysChloris.ExtrapolatedHumidity{Float64}, TempVecB_ittm2Ext::UrbanTethysChloris.ExtrapolatedTempVecB{Float64}, Meteo_ittm::UrbanTethysChloris.Meteotm1{Float64}, RESPreCalc::Bool, fconvPreCalc::Bool, fconv::Float64, rsRoofPreCalc::@NamedTuple{rs_sun::Float64, rs_shd::Float64, Ci_sun::Float64, Ci_shd::Float64}, rsGroundPreCalc::@NamedTuple{rs_sun_L::Float64, rs_shd_L::Float64, Ci_sun_L::Float64, Ci_shd_L::Float64}, rsTreePreCalc::@NamedTuple{rs_sun_H::Float64, rs_shd_H::Float64, Ci_sun_H::Float64, Ci_shd_H::Float64}; iterations::Int64, f_tol::Float64)
   @ UrbanTethysChloris F:\TRANSCODE_UTC\Julia\src\f_solver_tot.jl:116
 [4] f_solver_tot!(model::UrbanTethysChloris.Model{Float64}, TempVec_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempVec{Float64}, TempVecB_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempVecB{Float64}, Humidity_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Humidity{Float64}, Int_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Interception{Float64}, ExWater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.ExWater{Float64, 4, 13}, Vwater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Vwater{Float64, 4, 13}, Owater_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.Owater{Float64, 4, 13}, SoilPotW_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.SoilPotW{Float64}, CiCO2Leaf_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.CiCO2Leaf{Float64}, TempDamp_ittm::UrbanTethysChloris.ModelComponents.ModelVariables.TempDamp{Float64}, ViewFactor::UrbanTethysChloris.RayTracing.ViewFactor{Float64}, WallLayers::@NamedTuple{dz1_wall::Float64, dz2_wall::Float64}, ParInterceptionTree::@NamedTuple{Sp_In::Float64}, ParCalculation::@NamedTuple{dth::Float64, dts::Int64, row::Float64, cp_atm::Float64, rho_atm::Float64}, ParHVAC::UrbanTethysChloris.ModelComponents.Parameters.HVACParameters{Float64}, BEM_on::Bool, TempVec_ittm2Ext::UrbanTethysChloris.ExtrapolatedTempVec{Float64}, Humidity_ittm2Ext::UrbanTethysChloris.ExtrapolatedHumidity{Float64}, TempVecB_ittm2Ext::UrbanTethysChloris.ExtrapolatedTempVecB{Float64}, Meteo_ittm::UrbanTethysChloris.Meteotm1{Float64}, RESPreCalc::Bool, fconvPreCalc::Bool, fconv::Float64, rsRoofPreCalc::@NamedTuple{rs_sun::Float64, rs_shd::Float64, Ci_sun::Float64, Ci_shd::Float64}, rsGroundPreCalc::@NamedTuple{rs_sun_L::Float64, rs_shd_L::Float64, Ci_sun_L::Float64, Ci_shd_L::Float64}, rsTreePreCalc::@NamedTuple{rs_sun_H::Float64, rs_shd_H::Float64, Ci_sun_H::Float64, Ci_shd_H::Float64})
   @ UrbanTethysChloris F:\TRANSCODE_UTC\Julia\src\f_solver_tot.jl:85
 [5] run_simulation(model::UrbanTethysChloris.Model{Float64}, forcing::UrbanTethysChloris.ModelComponents.ForcingInputs.ForcingInputSet{Float64, 1}; NN::Int64, mc_sample_size::Int64, n_rays::Int64, RESPreCalc::Bool, fconvPreCalc::Bool, BEM_on::Bool, WallLayers::@NamedTuple{dz1_wall::Float64, dz2_wall::Float64}, ParInterceptionTree::@NamedTuple{Sp_In::Float64}, ViewFactors::Nothing, O33::@NamedTuple{roof::Float64, ground::Float64}, output_level::UrbanTethysChloris.ModelComponents.ExtendedOutputs)
   @ UrbanTethysChloris F:\TRANSCODE_UTC\Julia\src\run_simulation.jl:173
 [6] macro expansion
   @ F:\TRANSCODE_UTC\Julia\examples\dubai\run_dubai_save_results.jl:61 [inlined]
 [7] top-level scope
   @ .\timing.jl:421
in expression starting at F:\TRANSCODE_UTC\Julia\examples\dubai\run_dubai_save_results.jl:60
```

## Related issues

There is no related issue. This is a bug reported by @liantaiqi

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/EPFL-ENAC/UrbanTethysChloris.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
